### PR TITLE
Propose explicit `vendor` and `lint` relationship

### DIFF
--- a/index.md
+++ b/index.md
@@ -110,28 +110,23 @@ While not fixed requirements these are a list of things to consider when choosin
 A set of automated systems will be employed to verify that all vendored modules
 continue to meet the policy.
 
-* `mach lint node`: Primarily intended for CI, runs checks that no modules or
-dependencies use a disallowed license or have known security vulnerabilities.
-Verifies that `package-lock.json` is valid (does not pull code from unexpected
-registries).
+* `mach lint node`: Runs checks that no modules or dependencies use a disallowed license
+or have known security vulnerabilities.  Verifies that `package-lock.json` is valid (does
+not pull code from unexpected registries).  This is intended to be used locally (by
+`mach vendor node`), as well periodically on CI (to maintain the invariants).
 
     <details><summary>Details...</summary>
 
-    For security vulnerabilities this will rely on npm audit since snyk
-    requires an account and we shouldn’t expect developers to need to sign up to
-    run basic checks.
+    There are likely to be slight different options for CI use (e.g. we may additionally
+    do checks that require online resources or accounts, such as snyk, and we
+    don't want to unnecessarily burden local developers).
     </details>
 
 * Automated jobs run on treeherder for new phabricator revisions that affect
   node files and run periodically to verify existing modules.
 
-  <details><summary>Details...</summary>
-  This will include the tests from the above lint checks as well as using snyk
-  (which means there will have to be an account that our CI can use).
-  </details>
-
-* `mach vendor node`: Adds a new module to the `dependencies` or
-  `devDependencies` of `package.json` and validates it and its dependency tree
+* `mach vendor node`: Adds new modules to the `dependencies` or
+  `devDependencies` of `package.json` using and validates it and its dependency tree
   as above.
 
 * Herald rule to automatically add `nodejs-peers` as a blocking reviewer to any revisions that modify `node_modules`, `package.json` or `package-lock.json`.


### PR DESCRIPTION
It becomes much easier to write the vendoring and reviewing docs if we have a clear, explicit relationship between the `mach vendor lint` and `mach vendor node` steps.  Sound reasonable, @Mossop?