### PR TITLE
Policy selection move

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ Current explicit non-goals of this policy include:
 * Full code review of all modules added to node_modules in mozilla-central.
 * Covering node usage in repositories outside of mozilla-central and the integration branches, even if they may be used to generate artifacts that eventually land in mozilla-central.
 
-### Policy
+### General Policy
 * Node modules may only be used at build time or before (e.g. automated scripts and linting tools).
 
   <details><summary>Details...</summary>
@@ -38,18 +38,33 @@ Current explicit non-goals of this policy include:
 
 
 * Introduction or updates of vendored modules require review by a nodejs peer.
+
+* Any introduction of modules including cryptographic code requires additional review from a cryptographic expert.
+
 * Any changes to the vendored node modules should be landed as a standalone changeset also containing any changes required to keep the tree building with an appropriate description describing the need and review results.
 
   <details><summary>Why...</summary>
   The intent here is to maintain a working tree across all related commits so that VCS bisect functionality continues to work.
   </details>
 
-* All vendored node modules (and the entire dependency tree) must be licensed
-  under acceptable licenses based on the [licensing
-  runbook](https://docs.google.com/document/d/1Oguqp43W4_ChyroJ9AJAzG1jSwkUWfKvBKVvrDxVsMg/comment).
-  [XXX check with mhoye to ensure this is ok to post publicly]
+### Package selection
 
-* Any introduction of modules including cryptographic code requires additional review from a cryptographic expert.
+All vendored node modules (and their entire dependency tree) must be licensed
+under acceptable licenses based on the [licensing
+runbook](https://docs.google.com/document/d/1Oguqp43W4_ChyroJ9AJAzG1jSwkUWfKvBKVvrDxVsMg/comment).
+[XXX check with mhoye to ensure this is ok to post publicly]
+
+While not fixed requirements these are a list of things to consider when
+choosing a module to vendor:
+
+* Size of module and dependency tree
+* Update frequency
+* Test coverage
+* Responsiveness to bugs and security vulnerabilities.
+* Random sample to evaluate likely code quality.
+* Does this inject any code into the final build or have any other inherent security risks?
+* Any general opinions of the module found in the Node community.
+
 * Modules including binary code will only be approved in special circumstances.
   <details><summary>Why...</summary>
   The primary intent here is to avoid the implementation complexity needed for multiple platform-specific binaries in the vendored tree.  This will be handled by having `mach vendor node` pass `--ignore-scripts` to `npm`.  Note that the failure modes of that switch are package-dependent, which could lead to unexpected build behaviors/failures.  We may wish to have the vendoring code and reviewer docs emit a message suggestion manually inspecting the ignore scripts to avoid this.
@@ -92,16 +107,6 @@ Current explicit non-goals of this policy include:
   one per line, with “dep:” at the beginning of such lines.  Other schemes
   could be considered.
   </details>
-
-### Package selection
-While not fixed requirements these are a list of things to consider when choosing a module to vendor:
-* Size of module and dependency tree
-* Update frequency
-* Test coverage
-* Responsiveness to bugs and security vulnerabilities.
-* Random sample to evaluate likely code quality.
-* Does this inject any code into the final build or have any other inherent security risks?
-* Any general opinions of the module found in the Node community.
 
 See also https://blog.tidelift.com/how-to-choose-open-source-packages-well for
 more thoughts on this.

--- a/index.md
+++ b/index.md
@@ -93,13 +93,6 @@ Current explicit non-goals of this policy include:
   could be considered.
   </details>
 
-### Vulnerability response
-
-When Mozilla are made aware of a vulnerability in a vendored node module either via public announcement or private disclosure it is generally expected that the team using the module in question will be responsible for determining the best solution available. The NodeJS module peers will generally act in an advisory role helping where necessary with understanding the threats presented by a vulnerability. If the feature in question is unowned, then the NodeJS peers may take a more active role in finding a solution.
-<details><summary>More about ownership...</summary>
-The NodeJS peers should not be considered as owning all of the vendored node module code.
-</details>
-
 ### Package selection
 While not fixed requirements these are a list of things to consider when choosing a module to vendor:
 * Size of module and dependency tree
@@ -112,6 +105,13 @@ While not fixed requirements these are a list of things to consider when choosin
 
 See also https://blog.tidelift.com/how-to-choose-open-source-packages-well for
 more thoughts on this.
+
+### Vulnerability response
+
+When Mozilla are made aware of a vulnerability in a vendored node module either via public announcement or private disclosure it is generally expected that the team using the module in question will be responsible for determining the best solution available. The NodeJS module peers will generally act in an advisory role helping where necessary with understanding the threats presented by a vulnerability. If the feature in question is unowned, then the NodeJS peers may take a more active role in finding a solution.
+<details><summary>More about ownership...</summary>
+The NodeJS peers should not be considered as owning all of the vendored node module code.
+</details>
 
 ### Automated tools
 A set of automated systems will be employed to verify that all vendored modules


### PR DESCRIPTION
This rearranges the main policy doc so that:

* the Policy section is renamed to General Policy, because it's only part of the thing...
* Vulnerabilities is shifted later so that General Policy and Package Selection, which are more closely related, are together.
* moves some points around so that things that were really about Package Selection are there, rather than in the General Policy section.

The intent is that this allows makes the main page clearer, and also makes it easier to avoid duplicate content by allowing the How-To-Vendor page to simply refer to sections of the main page.

@Mossop seem reasonable?