### PR TITLE
Reduce save options

### DIFF
--- a/how-to-vendor.md
+++ b/how-to-vendor.md
@@ -13,7 +13,7 @@
    <details><summary>Details</summary>
 
     To be implemented in `mach vendor node install`:
-     * ```npm install --save-exact --save-dev|---save|--save-optional --no-bin-links --no-optional package@version --ignore-scripts```
+     * ```npm install --save-exact --save-dev --no-bin-links --no-optional package@version --ignore-scripts```
      * run `mach node lint`, which will:
        * run a license linter locally (until implemented, see http://npm.broofa.com/)
        * run `npm audit`
@@ -35,5 +35,5 @@
 
 ### Removing a package
 
-1. Use `npm uninstall --save|--save-dev|--save-option`
+1. Use `npm uninstall --save-dev`
 2. Commit and review as usual

--- a/how-to-vendor.md
+++ b/how-to-vendor.md
@@ -1,12 +1,12 @@
 # Step-By-Step Vendoring Guide
 ### Vendoring in a new package
 
-1. Reach out to a [NodeJS module peer](XXXLINKME), and request their help on
+1. Reach out to a [NodeJS module peer](XXXLINKME), and request their help with
   choosing and landing this package.
 2. Review available packages with functionality you want, keeping in mind the
   guideliness in the [Package Selection section of the main policy
   doc](./index#package-selection).
-3. Work with your reviewer to select a package to select the best package
+3. Work with your reviewer to select the best package
 4. Use `mach vendor node install` to vendor in the package (this will handle
    installing with the correct `npm` options and validating security and
    license invariants).
@@ -22,7 +22,7 @@
    </details>
 5. Review the generated patch to be sure it looks like you would expect.
 6. Commit as per the General Policy section.
-7. Upload your patch to Phabrictor and request review.
+7. Upload your patch to Phabricator and request review.
 
 ### Updating an existing package
 

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ details {margin-bottom: 16px;}
 
 ## NodeJS
 
-Intended to define the policy that will be followed for vendored node modules and how it will be verified.
+Defines the policy that will be followed for vendored node modules and the automated systems that will be put in place to ensure compliance.
 
 ### Non-goals
 Current explicit non-goals of this policy include:
@@ -116,7 +116,7 @@ more thoughts on this.
 
 ### Security
 
-Much of this policy has been written in a way to try and manage and mitigate general
+Much of this policy has been written in a way that tries to manage and mitigate general
 third-party vendoring security concerns.
 
 #### NPM-specific Threat-Modeling and Mitigation


### PR DESCRIPTION
Given that we intend node modules to only be used at build time it seems that `--save-dev` is the only choice we'd want to use now?